### PR TITLE
Fix empty paths

### DIFF
--- a/src/Path.php
+++ b/src/Path.php
@@ -147,7 +147,9 @@ class Path implements \ArrayAccess, \Countable, \IteratorAggregate
     public function __construct($parts, $directorySeparator = DIRECTORY_SEPARATOR)
     {
         // trim last element if empty
-        if (empty($parts[count($parts) - 1])) {
+        if (empty($parts[count($parts) - 1]) &&
+            !(count($parts) === 2 && empty($parts[0])) // don't trim for single separator '/'
+        ) {
             array_pop($parts);
         }
         $this->directorySeparator = $directorySeparator;

--- a/src/Path.php
+++ b/src/Path.php
@@ -241,6 +241,13 @@ class Path implements \ArrayAccess, \Countable, \IteratorAggregate
         }
         $this->info  = [];
         $parts       = $this->parts;
+        if (empty($parts)) {
+            $this->info = [
+                self::INFO_BASENAME => '',
+                self::INFO_FILENAME => '',
+            ];
+            return;
+        }
         $basename    = array_pop($parts);
 
         $this->info[self::INFO_BASENAME] = $basename;

--- a/tests/PathTest.php
+++ b/tests/PathTest.php
@@ -38,6 +38,7 @@ class PathTest extends \PHPUnit_Framework_TestCase
             ['/foo.baz'],
             ['/foo/bar.baz'],
             [''],
+            ['/'],
         ];
     }
 

--- a/tests/PathTest.php
+++ b/tests/PathTest.php
@@ -37,6 +37,7 @@ class PathTest extends \PHPUnit_Framework_TestCase
             ['foo/bar.baz'],
             ['/foo.baz'],
             ['/foo/bar.baz'],
+            [''],
         ];
     }
 


### PR DESCRIPTION
Fix some special cases where our path class wasn't matching the output for `pathinfo`.
